### PR TITLE
Bloquear novos cadastros de usuários por meio de variável de ambiente

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,8 @@ POSTGRES_DB=openmonetis_db
 # Gere com: openssl rand -base64 32
 BETTER_AUTH_SECRET=your-secret-key-here-change-this
 BETTER_AUTH_URL=http://localhost:3000
+# Bloqueia novos cadastros quando true/1/yes/on
+DISABLE_SIGNUP=false
 
 # === Portas ===
 APP_PORT=3000
@@ -60,3 +62,6 @@ OPENROUTER_API_KEY=
 # Logos automáticos de estabelecimentos. Cadastre em https://www.logo.dev
 LOGO_DEV_TOKEN=
 LOGO_DEV_SECRET_KEY=
+
+# === Desativar cadastros de novos usuários ===
+DISABLE_SIGNUP=true

--- a/.env.example
+++ b/.env.example
@@ -17,7 +17,8 @@ POSTGRES_DB=openmonetis_db
 # Gere com: openssl rand -base64 32
 BETTER_AUTH_SECRET=your-secret-key-here-change-this
 BETTER_AUTH_URL=http://localhost:3000
-# Bloqueia novos cadastros quando true/1/yes/on
+
+# === Desativar cadastros de novos usuários ===
 DISABLE_SIGNUP=false
 
 # === Portas ===
@@ -62,6 +63,3 @@ OPENROUTER_API_KEY=
 # Logos automáticos de estabelecimentos. Cadastre em https://www.logo.dev
 LOGO_DEV_TOKEN=
 LOGO_DEV_SECRET_KEY=
-
-# === Desativar cadastros de novos usuários ===
-DISABLE_SIGNUP=true

--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ curl -fsSL https://raw.githubusercontent.com/felipegcoutinho/openmonetis/main/do
 # .env mínimo recomendado para produção
 BETTER_AUTH_SECRET=gere-um-valor-com-openssl-rand-base64-32
 BETTER_AUTH_URL=http://seu-dominio.com
+# Bloqueia novos cadastros quando true (default: false)
+DISABLE_SIGNUP=false
 
 # 3. Suba tudo
 docker compose up -d
@@ -471,6 +473,9 @@ OPENROUTER_API_KEY=
 # Ambas as variáveis são runtime — basta definir no host; nenhum build arg necessário.
 LOGO_DEV_TOKEN=
 LOGO_DEV_SECRET_KEY=
+
+# Autenticação
+DISABLE_SIGNUP=false    # Bloqueia novos cadastros (true/false)
 ```
 
 ---

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,5 +1,8 @@
 import { LoginForm } from "@/features/auth/components/login-form";
 
 export default function LoginPage() {
-	return <LoginForm />;
+	const disableSignupValue = process.env.DISABLE_SIGNUP?.toLowerCase();
+	const signupDisabled = disableSignupValue === "true";
+
+	return <LoginForm signupDisabled={signupDisabled} />;
 }

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,8 +1,6 @@
+import { isSignupDisabled } from "@/shared/lib/auth/signup";
 import { LoginForm } from "@/features/auth/components/login-form";
 
 export default function LoginPage() {
-	const disableSignupValue = process.env.DISABLE_SIGNUP?.toLowerCase();
-	const signupDisabled = disableSignupValue === "true";
-
-	return <LoginForm signupDisabled={signupDisabled} />;
+	return <LoginForm signupDisabled={isSignupDisabled()} />;
 }

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -1,5 +1,12 @@
+import { redirect } from "next/navigation";
 import { SignupForm } from "@/features/auth/components/signup-form";
 
 export default function SignupPage() {
+	const disableSignupValue = process.env.DISABLE_SIGNUP?.toLowerCase();
+	const signupDisabled = disableSignupValue === "true"
+	if (signupDisabled) {
+		redirect("/login");
+	}
+
 	return <SignupForm />;
 }

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -1,10 +1,9 @@
 import { redirect } from "next/navigation";
+import { isSignupDisabled } from "@/shared/lib/auth/signup";
 import { SignupForm } from "@/features/auth/components/signup-form";
 
 export default function SignupPage() {
-	const disableSignupValue = process.env.DISABLE_SIGNUP?.toLowerCase();
-	const signupDisabled = disableSignupValue === "true"
-	if (signupDisabled) {
+	if (isSignupDisabled()) {
 		redirect("/login");
 	}
 

--- a/src/app/(landing-page)/page.tsx
+++ b/src/app/(landing-page)/page.tsx
@@ -30,6 +30,7 @@ import { Badge } from "@/shared/components/ui/badge";
 import { Button } from "@/shared/components/ui/button";
 import { Card, CardContent } from "@/shared/components/ui/card";
 import { getOptionalUserSession } from "@/shared/lib/auth/server";
+import { isSignupDisabled } from "@/shared/lib/auth/signup";
 
 export default async function Page() {
 	const [session, headersList, githubStats] = await Promise.all([
@@ -43,8 +44,7 @@ export default async function Page() {
 		"",
 	).replace(/:\d+$/, "");
 	const isPublicDomain = !!(publicDomain && hostname === publicDomain);
-	const disableSignupValue = process.env.DISABLE_SIGNUP?.toLowerCase();
-	const signupDisabled = disableSignupValue === "true";
+	const signupDisabled = isSignupDisabled();
 	const metricsItems = getMetricsItems(githubStats.stars, githubStats.forks);
 
 	return (

--- a/src/app/(landing-page)/page.tsx
+++ b/src/app/(landing-page)/page.tsx
@@ -43,6 +43,8 @@ export default async function Page() {
 		"",
 	).replace(/:\d+$/, "");
 	const isPublicDomain = !!(publicDomain && hostname === publicDomain);
+	const disableSignupValue = process.env.DISABLE_SIGNUP?.toLowerCase();
+	const signupDisabled = disableSignupValue === "true";
 	const metricsItems = getMetricsItems(githubStats.stars, githubStats.forks);
 
 	return (
@@ -86,20 +88,23 @@ export default async function Page() {
 										Entrar
 									</Button>
 								</Link>
-								<Link href="/signup">
-									<Button
-										variant="ghost"
-										size="sm"
-										className="h-9 text-primary-foreground/75 hover:bg-primary-foreground/10 hover:text-primary-foreground shadow-none dark:text-white/75 dark:hover:bg-white/10 dark:hover:text-white"
-									>
-										Começar
-									</Button>
-								</Link>
+								{!signupDisabled && (
+									<Link href="/signup">
+										<Button
+											variant="ghost"
+											size="sm"
+											className="h-9 text-primary-foreground/75 hover:bg-primary-foreground/10 hover:text-primary-foreground shadow-none dark:text-white/75 dark:hover:bg-white/10 dark:hover:text-white"
+										>
+											Começar
+										</Button>
+									</Link>
+								)}
 							</div>
 						))}
 					<MobileNav
 						isPublicDomain={isPublicDomain}
 						isLoggedIn={!!session?.user}
+						signupDisabled={signupDisabled}
 					/>
 				</nav>
 			</NavbarShell>
@@ -707,3 +712,5 @@ export default async function Page() {
 		</div>
 	);
 }
+
+

--- a/src/features/auth/components/login-form.tsx
+++ b/src/features/auth/components/login-form.tsx
@@ -21,10 +21,18 @@ import { GoogleAuthButton } from "./google-auth-button";
 
 type DivProps = React.ComponentProps<"div">;
 
+interface LoginFormProps extends DivProps {
+	signupDisabled?: boolean;
+}
+
 const authLinkClassName =
 	"font-medium text-foreground/88 underline decoration-border underline-offset-4 transition-colors hover:text-foreground hover:decoration-foreground/30 focus-visible:rounded-sm focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring/40";
 
-export function LoginForm({ className, ...props }: DivProps) {
+export function LoginForm({
+	className,
+	signupDisabled = false,
+	...props
+}: LoginFormProps) {
 	const router = useRouter();
 	const isGoogleAvailable = googleSignInAvailable;
 
@@ -233,12 +241,14 @@ export function LoginForm({ className, ...props }: DivProps) {
 							</div>
 						</Field>
 
-						<FieldDescription className="pt-1 text-center">
-							Não tem uma conta?{" "}
-							<a href="/signup" className={authLinkClassName}>
-								Inscreva-se
-							</a>
-						</FieldDescription>
+						{!signupDisabled && (
+							<FieldDescription className="pt-1 text-center">
+								Não tem uma conta?{" "}
+								<a href="/signup" className={authLinkClassName}>
+									Inscreva-se
+								</a>
+							</FieldDescription>
+						)}
 
 						<FieldDescription className="text-center text-sm text-muted-foreground">
 							<a href="/" className={authLinkClassName}>

--- a/src/features/landing/components/mobile-nav.tsx
+++ b/src/features/landing/components/mobile-nav.tsx
@@ -17,15 +17,20 @@ const navLinks = [
 	{ href: "#mobile", label: "Mobile" },
 	{ href: "#stack", label: "Stack" },
 	{ href: "#como-usar", label: "Como usar" },
-	{ href: "#para-quem-e", label: "Para quem é?" },
+	{ href: "#para-quem-e", label: "Para quem �?" },
 ];
 
 interface MobileNavProps {
 	isPublicDomain: boolean;
 	isLoggedIn: boolean;
+	signupDisabled: boolean;
 }
 
-export function MobileNav({ isPublicDomain, isLoggedIn }: MobileNavProps) {
+export function MobileNav({
+	isPublicDomain,
+	isLoggedIn,
+	signupDisabled,
+}: MobileNavProps) {
 	const [open, setOpen] = useState(false);
 
 	return (
@@ -75,12 +80,14 @@ export function MobileNav({ isPublicDomain, isLoggedIn }: MobileNavProps) {
 											Entrar
 										</Button>
 									</Link>
-									<Link href="/signup" onClick={() => setOpen(false)}>
-										<Button className="w-full gap-2">
-											Começar
-											<RiArrowRightSLine size={16} />
-										</Button>
-									</Link>
+									{!signupDisabled && (
+										<Link href="/signup" onClick={() => setOpen(false)}>
+											<Button className="w-full gap-2">
+												Começar
+												<RiArrowRightSLine size={16} />
+											</Button>
+										</Link>
+									)}
 								</>
 							)}
 						</div>

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -21,6 +21,11 @@ const PROTECTED_ROUTES = [
 // Rotas públicas (não requerem autenticação)
 const PUBLIC_AUTH_ROUTES = ["/login", "/signup"];
 
+function isSignupDisabled(): boolean {
+	const value = process.env.DISABLE_SIGNUP?.toLowerCase();
+	return value === "true";
+}
+
 function buildCsp(): string {
 	const isDev = process.env.NODE_ENV === "development";
 
@@ -60,6 +65,7 @@ function buildCsp(): string {
 
 export default async function proxy(request: NextRequest) {
 	const { pathname } = request.nextUrl;
+	const signupDisabled = isSignupDisabled();
 
 	// Multi-domain: block all routes except landing on public domain
 	// Normalize PUBLIC_DOMAIN: strip protocol and port if provided
@@ -77,6 +83,19 @@ export default async function proxy(request: NextRequest) {
 			return NextResponse.redirect(new URL("/", request.url));
 		}
 		return NextResponse.next();
+	}
+
+	if (signupDisabled) {
+		if (pathname === "/signup" || pathname.startsWith("/signup/")) {
+			return NextResponse.redirect(new URL("/login", request.url));
+		}
+
+		if (pathname.startsWith("/api/auth/sign-up")) {
+			return NextResponse.json(
+				{ error: "Novos cadastros estão desativados." },
+				{ status: 403 },
+			);
+		}
 	}
 
 	// Validate actual session, not just cookie existence

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,5 +1,6 @@
 import { type NextRequest, NextResponse } from "next/server";
 import { auth } from "@/shared/lib/auth/config";
+import { isSignupDisabled } from "@/shared/lib/auth/signup";
 
 // Rotas protegidas que requerem autenticação
 const PROTECTED_ROUTES = [
@@ -20,11 +21,6 @@ const PROTECTED_ROUTES = [
 
 // Rotas públicas (não requerem autenticação)
 const PUBLIC_AUTH_ROUTES = ["/login", "/signup"];
-
-function isSignupDisabled(): boolean {
-	const value = process.env.DISABLE_SIGNUP?.toLowerCase();
-	return value === "true";
-}
 
 function buildCsp(): string {
 	const isDev = process.env.NODE_ENV === "development";
@@ -65,7 +61,6 @@ function buildCsp(): string {
 
 export default async function proxy(request: NextRequest) {
 	const { pathname } = request.nextUrl;
-	const signupDisabled = isSignupDisabled();
 
 	// Multi-domain: block all routes except landing on public domain
 	// Normalize PUBLIC_DOMAIN: strip protocol and port if provided
@@ -85,9 +80,21 @@ export default async function proxy(request: NextRequest) {
 		return NextResponse.next();
 	}
 
+	// Validate actual session, not just cookie existence
+	const session = await auth.api.getSession({
+		headers: request.headers,
+	});
+
+	const isAuthenticated = !!session?.user;
+
+	// Block signup routes when signup is disabled
+	const signupDisabled = isSignupDisabled();
 	if (signupDisabled) {
 		if (pathname === "/signup" || pathname.startsWith("/signup/")) {
-			return NextResponse.redirect(new URL("/login", request.url));
+			// Authenticated users go directly to dashboard, not through login
+			return NextResponse.redirect(
+				new URL(isAuthenticated ? "/dashboard" : "/login", request.url),
+			);
 		}
 
 		if (pathname.startsWith("/api/auth/sign-up")) {
@@ -97,13 +104,6 @@ export default async function proxy(request: NextRequest) {
 			);
 		}
 	}
-
-	// Validate actual session, not just cookie existence
-	const session = await auth.api.getSession({
-		headers: request.headers,
-	});
-
-	const isAuthenticated = !!session?.user;
 
 	// Redirect authenticated users away from login/signup pages
 	if (isAuthenticated && PUBLIC_AUTH_ROUTES.includes(pathname)) {

--- a/src/shared/lib/auth/config.ts
+++ b/src/shared/lib/auth/config.ts
@@ -15,10 +15,7 @@ import { normalizeNameFromEmail } from "@/shared/lib/payers/utils";
 const googleClientId = process.env.GOOGLE_CLIENT_ID;
 const googleClientSecret = process.env.GOOGLE_CLIENT_SECRET;
 
-function isSignupDisabled(): boolean {
-	const value = process.env.DISABLE_SIGNUP?.toLowerCase();
-	return value === "true";
-}
+import { isSignupDisabled } from "@/shared/lib/auth/signup";
 
 /**
  * Extrai nome do usuário do perfil do Google com fallback hierárquico:

--- a/src/shared/lib/auth/config.ts
+++ b/src/shared/lib/auth/config.ts
@@ -1,5 +1,6 @@
 import { passkey } from "@better-auth/passkey";
 import { betterAuth } from "better-auth";
+import { APIError } from "better-auth/api";
 import { drizzleAdapter } from "better-auth/adapters/drizzle";
 import type { GoogleProfile } from "better-auth/social-providers";
 import { seedDefaultCategoriesForUser } from "@/shared/lib/categories/defaults";
@@ -13,6 +14,11 @@ import { normalizeNameFromEmail } from "@/shared/lib/payers/utils";
 
 const googleClientId = process.env.GOOGLE_CLIENT_ID;
 const googleClientSecret = process.env.GOOGLE_CLIENT_SECRET;
+
+function isSignupDisabled(): boolean {
+	const value = process.env.DISABLE_SIGNUP?.toLowerCase();
+	return value === "true";
+}
 
 /**
  * Extrai nome do usuário do perfil do Google com fallback hierárquico:
@@ -122,6 +128,12 @@ export const auth = betterAuth({
 	databaseHooks: {
 		user: {
 			create: {
+				before: async () => {
+					if (!isSignupDisabled()) return;
+					throw new APIError("FORBIDDEN", {
+						message: "Novos cadastros estão desativados.",
+					});
+				},
 				/**
 				 * Após criar novo usuário, inicializa:
 				 * 1. Categorias padrão (Receitas/Despesas)

--- a/src/shared/lib/auth/signup.ts
+++ b/src/shared/lib/auth/signup.ts
@@ -1,0 +1,7 @@
+/**
+ * Checks if new user signup is disabled via DISABLE_SIGNUP env var.
+ */
+export function isSignupDisabled(): boolean {
+	const value = process.env.DISABLE_SIGNUP?.toLowerCase();
+	return value === "true";
+}


### PR DESCRIPTION
Comecei a usar o openmonetis e senti a falta de desativar o cadastro de novos usuários

- Adicionei a variável de ambiente DISABLE_SIGNUP (default: false) para bloquear novos registros quando for true
- Adicionei o método isSignupDisabled para verificar se o cadastro está desativado
- Ocultei os botões que redirecionam para a tela de signup quando desativado
- Adicionei uma validação para redirecionar os usuários para fora da tela de signup quando desativado
- Bloqueei a criação de novos usuários na API quando desativado

- Atualizei a documentação em .env.example e README.md