### PR TITLE
Restringir proteção de leitura a faturas automáticas via prefixo de nota

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,13 @@ Todas as mudanças notáveis deste projeto serão documentadas neste arquivo.
 O formato é baseado em [Keep a Changelog](https://keepachangelog.com/pt-BR/1.1.0/),
 e este projeto adere ao [Versionamento Semântico](https://semver.org/lang/pt-BR/).
 
+## [2.5.8] - 2026-05-17
+
+Esta versão corrige a proteção indevida de lançamentos comuns categorizados como Pagamentos, preservando o bloqueio apenas para pagamentos automáticos de fatura gerados pelo sistema.
+
+### Corrigido
+- Lançamentos: despesas comuns na categoria `Pagamentos` voltam a permitir editar, remover, copiar e importar; somente lançamentos automáticos com anotação técnica `AUTO_FATURA:` permanecem protegidos.
+
 ## [2.5.7] - 2026-05-14
 
 Esta versão faz um polimento visual no relatório de análise de parcelas, deixando o estabelecimento como referência principal do card e mantendo o cartão visível de forma mais discreta no contexto da compra.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 > **⚠️ Não há versão online hospedada.** Você precisa clonar o repositório e rodar localmente ou no seu próprio servidor.
 
-[![Version](https://img.shields.io/badge/version-2.5.7-blue?style=flat-square)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-2.5.8-blue?style=flat-square)](CHANGELOG.md)
 [![Next.js](https://img.shields.io/badge/Next.js-black?style=flat-square&logo=next.js)](https://nextjs.org/)
 [![TypeScript](https://img.shields.io/badge/TypeScript-blue?style=flat-square&logo=typescript)](https://www.typescriptlang.org/)
 [![PostgreSQL](https://img.shields.io/badge/PostgreSQL-blue?style=flat-square&logo=postgresql)](https://www.postgresql.org/)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "openmonetis",
-	"version": "2.5.7",
+	"version": "2.5.8",
 	"private": true,
 	"packageManager": "pnpm@10.33.0",
 	"scripts": {

--- a/src/features/transactions/actions/single-actions.ts
+++ b/src/features/transactions/actions/single-actions.ts
@@ -9,6 +9,7 @@ import {
 	transactions,
 } from "@/db/schema";
 import { handleActionError } from "@/shared/lib/actions/helpers";
+import { ACCOUNT_AUTO_INVOICE_NOTE_PREFIX } from "@/shared/lib/accounts/constants";
 import { getUser } from "@/shared/lib/auth/server";
 import { db } from "@/shared/lib/db";
 import {
@@ -256,7 +257,14 @@ export async function updateTransactionAction(
 			return { success: false, error: "Lançamento não encontrado." };
 		}
 
-		const categoriasProtegidasEdicao = ["Saldo inicial", "Pagamentos"];
+		if (existing.note?.startsWith(ACCOUNT_AUTO_INVOICE_NOTE_PREFIX)) {
+			return {
+				success: false,
+				error: "Pagamentos com cartão são conciliados automaticamente.",
+			};
+		}
+
+		const categoriasProtegidasEdicao = ["Saldo inicial"];
 		if (
 			existing.category?.name &&
 			categoriasProtegidasEdicao.includes(existing.category.name)
@@ -419,7 +427,14 @@ export async function deleteTransactionAction(
 			return { success: false, error: "Lançamento não encontrado." };
 		}
 
-		const categoriasProtegidasRemocao = ["Saldo inicial", "Pagamentos"];
+		if (existing.note?.startsWith(ACCOUNT_AUTO_INVOICE_NOTE_PREFIX)) {
+			return {
+				success: false,
+				error: "Pagamentos com cartão são conciliados automaticamente.",
+			};
+		}
+
+		const categoriasProtegidasRemocao = ["Saldo inicial"];
 		if (
 			existing.category?.name &&
 			categoriasProtegidasRemocao.includes(existing.category.name)

--- a/src/features/transactions/components/table/transactions-columns.tsx
+++ b/src/features/transactions/components/table/transactions-columns.tsx
@@ -50,7 +50,10 @@ import {
 	TooltipContent,
 	TooltipTrigger,
 } from "@/shared/components/ui/tooltip";
-import { REFUND_NOTE_PREFIX } from "@/shared/lib/accounts/constants";
+import {
+	ACCOUNT_AUTO_INVOICE_NOTE_PREFIX,
+	REFUND_NOTE_PREFIX,
+} from "@/shared/lib/accounts/constants";
 import { resolveLogoSrc } from "@/shared/lib/logo";
 import { getAvatarSrc } from "@/shared/lib/payers/utils";
 import { formatDate } from "@/shared/utils/date";
@@ -654,14 +657,14 @@ function buildColumns({
 									Editar
 								</DropdownMenuItem>
 							)}
-							{row.original.categoriaName !== "Pagamentos" &&
+							{!row.original.note?.startsWith(ACCOUNT_AUTO_INVOICE_NOTE_PREFIX) &&
 								row.original.userId === currentUserId && (
 									<DropdownMenuItem onSelect={() => handleCopy(row.original)}>
 										<RiFileCopyLine className="size-4" />
 										Copiar
 									</DropdownMenuItem>
 								)}
-							{row.original.categoriaName !== "Pagamentos" &&
+							{!row.original.note?.startsWith(ACCOUNT_AUTO_INVOICE_NOTE_PREFIX) &&
 								row.original.userId !== currentUserId && (
 									<DropdownMenuItem onSelect={() => handleImport(row.original)}>
 										<RiFileCopyLine className="size-4" />

--- a/src/features/transactions/lib/page-helpers.ts
+++ b/src/features/transactions/lib/page-helpers.ts
@@ -551,8 +551,7 @@ export const mapTransactionsData = (rows: TransactionRowWithRelations[]) =>
 		hasAttachments: item.hasAttachments ?? false,
 		readonly:
 			Boolean(item.note?.startsWith(ACCOUNT_AUTO_INVOICE_NOTE_PREFIX)) ||
-			item.category?.name === "Saldo inicial" ||
-			item.category?.name === "Pagamentos",
+			item.category?.name === "Saldo inicial",
 	}));
 
 const sortByLabel = <T extends { label: string }>(items: T[]) =>


### PR DESCRIPTION
Este PR corrige um problema onde transações manuais legítimas eram marcadas incorretamente como *read-only* (somente leitura) na interface de usuário. 

Antes, o sistema utilizava apenas o nome da categoria (`"Pagamentos"`) como critério para desabilitar as ações de edição e remoção. Agora, a validação foi refinada para verificar a origem técnica do lançamento através do prefixo da nota (`AUTO_FATURA:`).

Fixes #60 

## O que mudou
* **Refatoração do critério de proteção:** Substituída a validação fraca baseada na string do nome da categoria (`item.category?.name === "Pagamentos"`) por uma checagem baseada em metadados técnicos (`item.note?.startsWith("AUTO_FATURA:")`).
* **Preservação de regras de negócio:** A proteção para lançamentos de saldo inicial (`note === "saldo inicial"`) permanece intacta.
* **Liberação da UI:** Lançamentos manuais categorizados como "Pagamentos" agora exibem corretamente as ações de **Editar** e **Remover** e o botão **Alterar**.

## Como Testar
1. Acesse a fatura de um cartão.
2. Crie manualmente uma despesa (ou uma despesa parcelada) e atribua a ela a categoria **Pagamentos**.
3. Verifique se os botões de **Editar**, **Remover** e **Alterar** estão visíveis e funcionais.
4. Garanta que lançamentos gerados automaticamente pelo sistema (que contêm o prefixo `AUTO_FATURA:` na nota) continuem devidamente bloqueados para edição.