### PR TITLE
Correção do CSS do dialog de adicionar transação

### DIFF
--- a/src/features/transactions/components/dialogs/transaction-dialog/transaction-dialog.tsx
+++ b/src/features/transactions/components/dialogs/transaction-dialog/transaction-dialog.tsx
@@ -569,7 +569,7 @@ export function TransactionDialog({
 				>
 					<div
 						ref={scrollContainerRef}
-						className="min-h-0 min-w-0 flex-1 overscroll-contain"
+						className="-mx-1 min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto overscroll-contain px-1 pb-1"
 					>
 						{/* Detalhes */}
 						<div className="space-y-3">

--- a/src/features/transactions/components/dialogs/transaction-dialog/transaction-dialog.tsx
+++ b/src/features/transactions/components/dialogs/transaction-dialog/transaction-dialog.tsx
@@ -569,7 +569,7 @@ export function TransactionDialog({
 				>
 					<div
 						ref={scrollContainerRef}
-						className="min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto overscroll-contain pr-1 pb-1"
+						className="min-h-0 min-w-0 flex-1 overscroll-contain"
 					>
 						{/* Detalhes */}
 						<div className="space-y-3">


### PR DESCRIPTION
Esse PR corrige o CSS do dialog de adicionar transação e o alinhamento entre os campos e os botões.

Antes:
<img width="582" height="654" alt="image" src="https://github.com/user-attachments/assets/0777e898-a557-4a0e-b548-eea783883e9a" />

Depois:
<img width="584" height="648" alt="image" src="https://github.com/user-attachments/assets/13fbdc65-fcfe-418d-aba0-0ba5afe3eb23" />