### PR TITLE
Ajusta o pré-preenchimento de data do dialog de múltiplas transações

### DIFF
--- a/src/features/transactions/components/dialogs/mass-add-dialog.tsx
+++ b/src/features/transactions/components/dialogs/mass-add-dialog.tsx
@@ -123,10 +123,11 @@ interface TransactionRow {
 
 function createEmptyTransactionRow(
 	defaultPayerId?: string | null,
+	lastPurchaseDate?: string,
 ): TransactionRow {
 	return {
 		id: createClientSafeId(),
-		purchaseDate: getTodayDateString(),
+		purchaseDate: lastPurchaseDate ?? getTodayDateString(),
 		name: "",
 		amount: "",
 		categoryId: undefined,
@@ -180,9 +181,10 @@ export function MassAddDialog({
 	}, [categoryOptions, transactionType]);
 
 	const addTransaction = () => {
+		const lastTransaction = transactions[transactions.length - 1];
 		setTransactions([
 			...transactions,
-			createEmptyTransactionRow(defaultPayerId),
+			createEmptyTransactionRow(defaultPayerId, lastTransaction?.purchaseDate),
 		]);
 	};
 


### PR DESCRIPTION
Este PR modifica o comportamento do campo de data do dialog de adicionar múltiplas transações.

Ao adicionar uma nova linha de transação, a data agora é pré-preenchida com a data da última transação invés da data atual (útil quando estivermos adicionando transações antigas).